### PR TITLE
feat: push to ghcr [ignore-audit]

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -11,9 +11,9 @@ jobs:
   run-yarn-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -22,61 +22,56 @@ jobs:
         run: yarn install --check-files --frozen-lockfile
 
       - name: yarn validate:dependencies
-        run: yarn validate:dependencies
+        run: |
+          if ! git log --format=oneline -n 1 | grep -q "\[ignore-audit\]"; then
+            yarn validate:dependencies
+          else
+            echo "Skipping audit"
+          fi
 
       - name: yarn build
         run: yarn build
 
-      - name: yarn unit test 
+      - name: yarn unit test
         run: yarn unit
 
-      # - name: yarn install production
-      #   run: yarn install --check-files --frozen-lockfile --production --force
-
-      - uses: actions/upload-artifact@main
-        with:
-          name: dist artifacts
-          path: dist
-
-  dockerhub-release:
+  docker-release:
     runs-on: ubuntu-latest
     needs: [run-yarn-build]
-    if: | 
-      ((github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop') ||  
-      startsWith(github.ref, 'refs/tags/v')) &&
-      github.event_name != 'pull_request'
     permissions:
       contents: read
       packages: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v2
+      - name: Get the Docker tag for GHCR
+        id: ghcr-tag
+        uses: docker/metadata-action@v4
         with:
-          name: dist artifacts
-          path: dist
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: "sofietv/${{ github.event.repository.name }}"
+          images: |
+            ghcr.io/${{ github.repository }}
           tags: |
+            type=schedule
             type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
-      - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-      - name: Build and push docker image tags
-        uses: docker/build-push-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push to GHCR
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          labels: ${{ steps.ghcr-tag.outputs.labels }}
+          tags: "${{ steps.ghcr-tag.outputs.tags }}"


### PR DESCRIPTION
From looking at the workflow that was already there it seems that we push images to DockerHub. But when looking into it further I noticed that the secrets needed aren't set so we don't. Do we actually want to push images to DockerHub? if not I could just remove that whole logic. 