### PR TITLE
fix: Ruby floating faders during fade-on/fade-out (SOFIE-4001)

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -15,13 +15,16 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: yarn install
-        run: yarn install --check-files --frozen-lockfile
+        run: yarn install
 
       # - name: yarn validate:dependencies
       #   run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,6 @@ EXPOSE 1176/tcp
 EXPOSE 1176/udp
 EXPOSE 5255/tcp
 EXPOSE 5255/udp
+ENV NODE_ENV=production
+ENV LOG_LEVEL=trace
 CMD ["node", "server/dist/server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,5 @@ EXPOSE 1176/udp
 EXPOSE 5255/tcp
 EXPOSE 5255/udp
 ENV NODE_ENV=production
-ENV LOG_LEVEL=trace
+ENV LOG_LEVEL=info
 CMD ["node", "server/dist/server"]

--- a/Dockerfile.circle
+++ b/Dockerfile.circle
@@ -1,5 +1,0 @@
-FROM node:12.16.0-alpine
-RUN apk add --no-cache tzdata
-COPY . /opt/sisyfos-audio-controller
-WORKDIR /opt/sisyfos-audio-controller
-CMD ["yarn", "start"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sisyfos-audio-controller",
-  "version": "4.19.0-nrk-release52.2",
+  "version": "4.22.0-nrk-release52.3",
   "description": "Audio mixer build with the logic from a video mixer",
   "license": "MIT",
   "author": {

--- a/server/package.json
+++ b/server/package.json
@@ -30,7 +30,7 @@
         "osc": "^2.4.5",
         "performance-now": "^2.1.0",
         "redux": "^5.0.1",
-        "shared": "file:../shared",
+        "shared": "*",
         "socket.io": "^4.7.4",
         "tslib": "^2.6.2",
         "vmix-js-utils": "^4.0.19",

--- a/server/src/utils/AutomationConnection.ts
+++ b/server/src/utils/AutomationConnection.ts
@@ -89,8 +89,7 @@ export class AutomationConnection {
             }
 
             logger
-                .data(message)
-                .debug(`RECEIVED AUTOMATION MESSAGE: ${message.address}`)
+                .debug(`RECEIVED AUTOMATION MESSAGE: ${message.address}`, { data: { message } })
 
             // Set state of Sisyfos:
             if (check('CHANNEL_PGM_ON_OFF')) {

--- a/server/src/utils/MixerConnection.ts
+++ b/server/src/utils/MixerConnection.ts
@@ -175,6 +175,8 @@ export class MixerGenericConnection {
     delayedFadeActiveDisable = (mixerIndex: number, channelIndex: number) => {
         this.mixerTimers[mixerIndex].fadeActiveTimer[channelIndex] = setTimeout(
             () => {
+                logger.trace(`Clearing fadeActive on ${mixerIndex} Ch ${channelIndex}`)
+
                 store.dispatch({
                     type: ChannelActionTypes.FADE_ACTIVE,
                     mixerIndex: mixerIndex,
@@ -475,9 +477,13 @@ export class MixerGenericConnection {
         let startLevel = state.channels[0].chMixerConnection[mixerIndex].channel[
                 channelIndex].outputLevel
 
-        if (state.channels[0].chMixerConnection[mixerIndex].channel[channelIndex].fadeActive 
+        if (state.channels[0].chMixerConnection[mixerIndex].channel[channelIndex].fadeActive
                 && this.currentOutputLevel[channelIndex] !== undefined
             ) {
+            logger.trace(
+              `Preparing fade on ${mixerIndex} Ch ${channelIndex} level ${startLevel} is overriden by ${this.currentOutputLevel[channelIndex]} because fadeActive`
+            )
+
             startLevel = this.currentOutputLevel[channelIndex]
         }
 
@@ -494,7 +500,7 @@ export class MixerGenericConnection {
         let startLevel = state.channels[0].chMixerConnection[mixerIndex].channel[
             channelIndex].outputLevel
 
-        if (state.channels[0].chMixerConnection[mixerIndex].channel[channelIndex].fadeActive 
+        if (state.channels[0].chMixerConnection[mixerIndex].channel[channelIndex].fadeActive
                 && this.currentOutputLevel[channelIndex] !== undefined
             ) {
             startLevel = this.currentOutputLevel[channelIndex]
@@ -513,6 +519,10 @@ export class MixerGenericConnection {
         const startTimeAsMs = Date.now()
         const updateInterval: number = Math.floor(
             1000 / this.mixerProtocol[mixerIndex].MAX_UPDATES_PER_SECOND
+        )
+
+        logger.trace(
+          `Initiating fade on ${mixerIndex} Ch ${channelIndex} started ${startTimeAsMs}: from ${startLevel} to ${endLevel} at ${startTimeAsMs}`
         )
 
         this.clearTimer(mixerIndex, channelIndex)
@@ -551,6 +561,9 @@ export class MixerGenericConnection {
         const elapsedTimeMS = currentTimeMS - startTimeAsMs
 
         if (elapsedTimeMS >= fadeTime || endLevel === startLevel) {
+            logger.trace(
+              `Finishing fade on ${mixerIndex} Ch ${channelIndex} started ${startTimeAsMs}: from ${startLevel} to ${endLevel}, fadeTime: ${fadeTime}, elapsed: ${elapsedTimeMS}`
+            )
             this.mixerConnection[mixerIndex].updateFadeIOLevel(
                 channelIndex,
                 endLevel
@@ -567,15 +580,17 @@ export class MixerGenericConnection {
             return true
         }
 
-        this.currentOutputLevel[channelIndex] =
-            startLevel +
-            (endLevel - startLevel) *
-                Math.max(0, Math.min(1, elapsedTimeMS / fadeTime))
+        const diff = (endLevel - startLevel)
+        const progress = Math.max(0, Math.min(1, elapsedTimeMS / fadeTime))
+        const newLevel = startLevel + diff * progress
 
-        this.mixerConnection[mixerIndex].updateFadeIOLevel(
-            channelIndex,
-            this.currentOutputLevel[channelIndex]
+        this.currentOutputLevel[channelIndex] = newLevel
+
+        logger.trace(
+          `Doing fade on ${mixerIndex} Ch ${channelIndex} started ${startTimeAsMs}: from ${startLevel} to ${endLevel}, level: ${newLevel}, progress: ${progress}, fadeTime: ${fadeTime}, elapsed: ${elapsedTimeMS}`
         )
+
+        this.mixerConnection[mixerIndex].updateFadeIOLevel(channelIndex, newLevel)
 
         store.dispatch({
             type: ChannelActionTypes.SET_OUTPUT_LEVEL,

--- a/server/src/utils/MixerConnection.ts
+++ b/server/src/utils/MixerConnection.ts
@@ -435,12 +435,6 @@ export class MixerGenericConnection {
             )
             this.clearTimer(mixerIndex, channelIndex)
         }
-        store.dispatch({
-            type: ChannelActionTypes.FADE_ACTIVE,
-            mixerIndex: mixerIndex,
-            channel: channelIndex,
-            active: true,
-        })
         if (isOnAir && fadeTime === 0) {
             // If fadeTime is 0 - jump to level and don't use timer
             this.jumpToLevel(mixerIndex, channelIndex, faderIndex)
@@ -449,6 +443,12 @@ export class MixerGenericConnection {
         } else {
             this.fadeDown(mixerIndex, channelIndex, fadeTime)
         }
+        store.dispatch({
+          type: ChannelActionTypes.FADE_ACTIVE,
+          mixerIndex: mixerIndex,
+          channel: channelIndex,
+          active: true,
+        })
     }
 
     jumpToLevel = (mixerIndex: number, channelIndex: number, faderIndex: number) => {
@@ -561,6 +561,8 @@ export class MixerGenericConnection {
         const elapsedTimeMS = currentTimeMS - startTimeAsMs
 
         if (elapsedTimeMS >= fadeTime || endLevel === startLevel) {
+            this.currentOutputLevel[channelIndex] = endLevel
+
             logger.trace(
               `Finishing fade on ${mixerIndex} Ch ${channelIndex} started ${startTimeAsMs}: from ${startLevel} to ${endLevel}, fadeTime: ${fadeTime}, elapsed: ${elapsedTimeMS}`
             )

--- a/server/src/utils/mixerConnections/LawoRubyConnection.ts
+++ b/server/src/utils/mixerConnections/LawoRubyConnection.ts
@@ -278,11 +278,13 @@ export class LawoRubyMixerConnection implements MixerConnection {
                     const levelInDecibel: number = (
                         node.contents as Model.Parameter
                     ).value as number
-                    logger.trace(
-                        `Receiving Level from Ch ${ch}: ${levelInDecibel}`
-                    )
                     const minDeciBel = this.mixerProtocol.channelTypes[typeIndex].fromMixer
                         .CHANNEL_OUT_GAIN[0].min
+
+                    logger.trace(
+                        `Receiving Level from ${command} Ch ${ch - 1}: ${levelInDecibel}`
+                    )
+
                     if (
                         !state.channels[0].chMixerConnection[this.mixerIndex]
                             .channel[ch - 1].fadeActive &&
@@ -309,7 +311,7 @@ export class LawoRubyMixerConnection implements MixerConnection {
                         })
 
                         // toggle pgm based on level
-                        logger.trace(`Set Channel ${ch} pgmOn ${level > 0}`)
+                        logger.trace(`Set Ch ${ch - 1} pgmOn ${level > 0} from ${command} level ${level}: ${levelInDecibel}`)
                         store.dispatch({
                             type: FaderActionTypes.SET_PGM,
                             faderIndex: ch - 1,
@@ -351,10 +353,12 @@ export class LawoRubyMixerConnection implements MixerConnection {
             this.emberConnection.subscribe(
                 node as NumberedTreeNode<EmberElement>,
                 () => {
-                    logger.trace(`Receiving Gain from Ch ${ch}`)
                     const value = (node.contents as Model.Parameter)
                         .value as number
-                    const level = dbToFloat(value)
+                    const minDeciBel = this.mixerProtocol.channelTypes[typeIndex].fromMixer
+                        .CHANNEL_OUT_GAIN[0].min
+                    const level = dbToFloat(value, minDeciBel)
+                    logger.trace(`Receiving Gain from ${command} Ch ${ch - 1}: ${value}, level: ${level}`)
                     if (
                         ((node.contents as Model.Parameter).value as number) >
                         proto.min
@@ -389,7 +393,7 @@ export class LawoRubyMixerConnection implements MixerConnection {
 
         try {
             const node = await this.emberConnection.getElementByPath(command)
-            logger.debug(`set_cap ${ch} hasInputSel true`)
+            logger.debug(`set_cap ${ch - 1} hasInputSel true`)
             store.dispatch({
                 type: FaderActionTypes.SET_CAPABILITY,
                 faderIndex: ch - 1,
@@ -404,7 +408,7 @@ export class LawoRubyMixerConnection implements MixerConnection {
             this.emberConnection.subscribe(
                 node as NumberedTreeNode<EmberElement>,
                 () => {
-                    logger.trace(`Receiving InpSelector from Ch ${ch}`)
+                    logger.trace(`Receiving InpSelector from ${command} Ch ${ch - 1}`)
                     this.mixerProtocol.channelTypes[
                         typeIndex
                     ].fromMixer.CHANNEL_INPUT_SELECTOR.forEach(
@@ -428,7 +432,7 @@ export class LawoRubyMixerConnection implements MixerConnection {
             )
         } catch (e) {
             if (e.message.match(/could not find node/i)) {
-                logger.debug(`set_cap ${ch} hasInputSel false`)
+                logger.debug(`set_cap ${ch - 1} hasInputSel false`)
                 store.dispatch({
                     type: FaderActionTypes.SET_CAPABILITY,
                     faderIndex: ch - 1,
@@ -471,7 +475,7 @@ export class LawoRubyMixerConnection implements MixerConnection {
             this.emberConnection.subscribe(
                 node as NumberedTreeNode<EmberElement>,
                 () => {
-                    logger.trace(`Receiving AMix state from Ch ${ch}`)
+                    logger.trace(`Receiving AMix state from ${command} Ch ${ch - 1}`)
 
                     store.dispatch({
                         type: FaderActionTypes.SET_AMIX,
@@ -483,7 +487,7 @@ export class LawoRubyMixerConnection implements MixerConnection {
             )
         } catch (e) {
             if (e.message.match(/could not find node/i)) {
-                logger.debug(`set_cap ${ch - 1} hasAMix false`)
+                logger.debug(`set_cap ${command} Ch ${ch - 1} hasAMix false`)
                 store.dispatch({
                     type: FaderActionTypes.SET_CAPABILITY,
                     faderIndex: ch - 1,
@@ -491,7 +495,7 @@ export class LawoRubyMixerConnection implements MixerConnection {
                     enabled: false,
                 })
             }
-            logger.data(e).debug('error when subscribing to input selector')
+            logger.data(e).debug(`error when subscribing to input selector ${command}`)
         }
     }
 
@@ -507,13 +511,20 @@ export class LawoRubyMixerConnection implements MixerConnection {
 
         let message = mixerMessage.replace('{channel}', channelString)
 
+        const timestamp0 = performance.now()
+
         this.emberConnection
             .getElementByPath(message)
             .then((element: any) => {
                 const v = typeof value === 'string' ? parseFloat(value) : value
                 if (element.contents.value === v) return { response: undefined, sentOk: false } // contents is already the same - a bit risky but yolo
-
-                logger.trace(`Sending out message: ${message}`)
+                logger.trace(
+                  `Sending out message: ${message} val: ${v} typeof: ${typeof v}`,
+                  {
+                    epochBegin: timestamp0,
+                    diff: performance.now() - timestamp0,
+                  }
+                )
                 return this.emberConnection.setValue(element, v)
             })
             .then((req) => req.response)
@@ -530,7 +541,7 @@ export class LawoRubyMixerConnection implements MixerConnection {
             this.mixerProtocol.channelTypes[0].toMixer.CHANNEL_OUT_GAIN[0]
                 .mixerMessage
 
-        logger.trace(`Sending out Level: ${value}  To ${source}`)
+        logger.trace(`Sending out value: ${value}  To ${source}`)
 
         this.sendOutMessage(mixerMessage, channel, value)
     }

--- a/shared/src/reducers/channelsReducer.ts
+++ b/shared/src/reducers/channelsReducer.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../server/src/utils/logger'
 import {
     ChannelActionTypes,
 } from '../actions/channelActions'
@@ -118,11 +119,11 @@ export const channels = (
                                         (channel: Channel) => channel.channelType === typeIndex
                                     )
                                 }
-                            
+
                                 // Only set channel state if it exists in next state
                                 // And only if it does not exceed the number of channels in the type
                                 // This is to avoid setting state for channels that has been removed
-                                if (nextState[0].chMixerConnection[mixerIndex].channel[chIndexInState] !== undefined && 
+                                if (nextState[0].chMixerConnection[mixerIndex].channel[chIndexInState] !== undefined &&
                                     action.numberOfTypeChannels[mixerIndex].numberOfTypeInCh[typeIndex] > chIndexInType &&
                                     chIndexInState > -1
                                 ) {
@@ -136,7 +137,7 @@ export const channels = (
                                         mixerIndex].channel[chIndexInState].channelType = typeIndex
                                 }
                             }
-                            chIndexInState++  
+                            chIndexInState++
                             chIndexInType++
                         }
                     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -11623,16 +11623,7 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
-"shared@file:../shared::locator=server%40workspace%3Aserver":
-  version: 0.0.0
-  resolution: "shared@file:../shared#../shared::hash=54a9fe&locator=server%40workspace%3Aserver"
-  dependencies:
-    redux: "npm:^5.0.1"
-  checksum: 10c0/b6c60ce2d81f7c77199c9a249eed497e6cad9f1b22ec1d4002d35affd9fcf891bb7a4297113437b57391b96224fb43a40b04108df5c5726d779cc487ede0e3a7
-  languageName: node
-  linkType: hard
-
-"shared@workspace:shared":
+"shared@npm:*, shared@workspace:shared":
   version: 0.0.0-use.local
   resolution: "shared@workspace:shared"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -11575,7 +11575,7 @@ asn1@evs-broadcast/node-asn1:
     osc: "npm:^2.4.5"
     performance-now: "npm:^2.1.0"
     redux: "npm:^5.0.1"
-    shared: "file:../shared"
+    shared: "npm:*"
     socket.io: "npm:^4.7.4"
     ts-jest: "npm:^29.1.2"
     tslib: "npm:^2.6.2"
@@ -11623,16 +11623,7 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
-"shared@file:../shared::locator=server%40workspace%3Aserver":
-  version: 0.0.0
-  resolution: "shared@file:../shared#../shared::hash=8d9975&locator=server%40workspace%3Aserver"
-  dependencies:
-    redux: "npm:^5.0.1"
-  checksum: 10c0/7b7cd7efba75ecbcff8be7b56f68a9d05a726a8afba340146a498721b1c09c075bc58a6851b97e3f4d1d732f1551d4d8c1a2b9a0e797286ab8022e9ac7e9e714
-  languageName: node
-  linkType: hard
-
-"shared@workspace:shared":
+"shared@npm:*, shared@workspace:shared":
   version: 0.0.0-use.local
   resolution: "shared@workspace:shared"
   dependencies:


### PR DESCRIPTION
When doing fades in Sisyfos, faders will go via odd values, even when going from the same value to the same value.